### PR TITLE
Fixed Typo within OpenAPI definition

### DIFF
--- a/dfirtrack_api/openapi/openapi_dfirtrack.yml
+++ b/dfirtrack_api/openapi/openapi_dfirtrack.yml
@@ -2862,7 +2862,7 @@ paths:
       - api
 
 security:
-  - BasicAuth []
+  - BasicAuth: []
 components:
   schemas:
     Artifact:
@@ -3409,4 +3409,5 @@ components:
   securitySchemes:
     BasicAuth:
       type: http
+      description: HTTP Basic Authentication for DFIRTrack API.
       scheme: basic


### PR DESCRIPTION
Fix Typo in OpenAPI-Definition. The Typo disabled HTTP Basic Authentication. This should work now