### PR TITLE
Feature FIX User-Serializer within API

### DIFF
--- a/dfirtrack_api/serializers/dfirtrack_artifacts.py
+++ b/dfirtrack_api/serializers/dfirtrack_artifacts.py
@@ -49,10 +49,6 @@ class ArtifactSerializer(serializers.ModelSerializer):
         if instance.artifact_requested_time:
             representation['artifact_requested_time'] = instance.artifact_requested_time.strftime('%Y-%m-%dT%H:%M')
 
-        # get usernames
-        representation['artifact_created_by_user_id'] = instance.artifact_created_by_user_id.username
-        representation['artifact_modified_by_user_id'] = instance.artifact_modified_by_user_id.username
-
         return representation
 
     class Meta:

--- a/dfirtrack_api/serializers/dfirtrack_main.py
+++ b/dfirtrack_api/serializers/dfirtrack_main.py
@@ -27,9 +27,6 @@ class CaseSerializer(serializers.ModelSerializer):
         # change mandatory time strings
         representation['case_create_time'] = instance.case_create_time.strftime('%Y-%m-%dT%H:%M')
 
-        # get usernames
-        representation['case_created_by_user_id'] = instance.case_created_by_user_id.username
-
         return representation
 
     class Meta:
@@ -247,10 +244,6 @@ class SystemSerializer(serializers.ModelSerializer):
         if instance.system_deprecated_time:
             representation['system_deprecated_time'] = instance.system_deprecated_time.strftime('%Y-%m-%dT%H:%M')
 
-        # get usernames
-        representation['system_created_by_user_id'] = instance.system_created_by_user_id.username
-        representation['system_modified_by_user_id'] = instance.system_modified_by_user_id.username
-
         return representation
 
     class Meta:
@@ -400,12 +393,6 @@ class TaskSerializer(serializers.ModelSerializer):
             representation['task_finished_time'] = instance.task_finished_time.strftime('%Y-%m-%dT%H:%M')
         if instance.task_due_time:
             representation['task_due_time'] = instance.task_due_time.strftime('%Y-%m-%dT%H:%M')
-
-        # get usernames
-        if instance.task_assigned_to_user_id:
-            representation['task_assigned_to_user_id'] = instance.task_assigned_to_user_id.username
-        representation['task_created_by_user_id'] = instance.task_created_by_user_id.username
-        representation['task_modified_by_user_id'] = instance.task_modified_by_user_id.username
 
         return representation
 


### PR DESCRIPTION
We changed the representation manually of the "created_by", "modified_by" attributes within the API. Due to the change in the representation, API Calls had a real struggle hence they needed the user-id for the creation of e.g. a Artifact but in the Response after the creation the username was returned as type "string". 

This lead to really strange behaviour