### PR TITLE
Describe current commit via tag if head is detached from branch

### DIFF
--- a/dfirtrack_main/templatetags/dfirtrack_main_tags.py
+++ b/dfirtrack_main/templatetags/dfirtrack_main_tags.py
@@ -26,8 +26,10 @@ if not "CI" in environ:
         # not in GitHub action --> get and return current branch
         working_dir = getcwd()
         repo = Repo(working_dir)
-        branch = repo.active_branch
-        return branch
+        try:
+            return repo.active_branch
+        except TypeError:
+            return repo.git.describe('--tags')
 else:
     @register.simple_tag
     def dfirtrack_branch():


### PR DESCRIPTION
Fixes TypeError HEAD is a detached symbolic reference if a tag is checked out and deployed instead of a branch.

A similar way could also eventually be used for the CI case with parameter `--all` instead of `--tags`.