### PR TITLE
simplify handling of version information for page header

### DIFF
--- a/dfirtrack_main/templates/dfirtrack_main/maintemplate.html
+++ b/dfirtrack_main/templates/dfirtrack_main/maintemplate.html
@@ -72,21 +72,14 @@
                     </small>
 
                     <!-- DFIRTrack version number and branch -->
-                    <!-- dfirtrack_main.templatetags.dfirtrack_main_tags.dfirtrack_version   -->
+                    <!-- dfirtrack_main.templatetags.dfirtrack_main_tags.dfirtrack_version -->
                     <small>
                         {% dfirtrack_version %}
                     </small>
-
-                    <!-- register templatetag, otherwise following if-statement wont work -->
-                    {% github_ci as ci %}
-
-                    <!-- show current branch only if not in GitHub action -->
-                    {% if not ci %}
-                        <!-- dfirtrack_main.templatetags.dfirtrack_main_tags.dfirtrack_branch   -->                    
-                        <small class="text-muted">
-                            ({% dfirtrack_branch %})
-                        </small>
-                    {% endif %}
+                    <!-- dfirtrack_main.templatetags.dfirtrack_main_tags.dfirtrack_branch -->
+                    <small class="text-muted">
+                        ({% dfirtrack_branch %})
+                    </small>
                 </h3>
             </center>
         </div>

--- a/dfirtrack_main/templatetags/dfirtrack_main_tags.py
+++ b/dfirtrack_main/templatetags/dfirtrack_main_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from git import Repo
+from git import Repo, GitCommandError
 from os import environ, getcwd
 
 register = template.Library()
@@ -9,40 +9,17 @@ def dfirtrack_version():
     versionnumber = 'v1.2.1'
     return versionnumber
 
-"""
-following conditions are necessary for Pull Requests
-
-GitHub actions do some kind of `git checkout` on PRs, which causes
-'TypeError: HEAD is a detached symbolic reference as it points to...'
-
-multiple issues exists on this in https://github.com/gitpython-developers/GitPython
-actually solved, but does still not work here
-"""
-
-# check for GitHub action
-if not "CI" in environ:
-    @register.simple_tag
-    def dfirtrack_branch():
-        # not in GitHub action --> get and return current branch
-        working_dir = getcwd()
-        repo = Repo(working_dir)
+@register.simple_tag
+def dfirtrack_branch():
+    repo = Repo(getcwd())
+    try:
+        return repo.active_branch
+    except TypeError:
         try:
-            return repo.active_branch
-        except TypeError:
             return repo.git.describe('--tags')
-else:
-    @register.simple_tag
-    def dfirtrack_branch():
-        # in GitHub action --> return dummy value to avoid errors
-        return "unknown"
+        except GitCommandError:
+            return repo.git.describe('--all')
 
-# check for GitHub action
 @register.simple_tag
 def github_ci():
-    if not "CI" in environ:
-        # not in GitHub action --> show branch in maintemplate
-        ci = False
-    else:
-        # in GitHub action --> do not show branch in maintemplate
-        ci = True
-    return ci
+    return 'CI' in environ


### PR DESCRIPTION
Do not treat CI environment in a special way,
instead fallback to a tag instead of branch.