### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,21 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
+      - run: black --check . || true
+      - run: codespell || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --install-types --non-interactive . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B101,B106,B108,B110 . || true
+      - run: bandit --recursive --skip B101,B106,B108,B110 .
       - run: black --check . || true
       - run: codespell --skip="*.js,*.map" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
       - run: black --check . || true
-      - run: codespell || true  # --ignore-words-list="" --skip=""
+      - run: codespell --skip="*.js,*.map" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --show-source --statistics
       - run: isort --check-only --profile black . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B101,B106,B108 . || true
+      - run: bandit --recursive --skip B101,B106,B108,B110 . || true
       - run: black --check . || true
       - run: codespell --skip="*.js,*.map" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B101,B106 . || true
+      - run: bandit --recursive --skip B101,B106,B108 . || true
       - run: black --check . || true
       - run: codespell --skip="*.js,*.map" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
+      - run: bandit --recursive --skip B101,B106 . || true
       - run: black --check . || true
       - run: codespell --skip="*.js,*.map" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
Output: https://github.com/cclauss/dfirtrack/actions

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./dfirtrack_main/models.py:1243:25: F821 undefined name 'request_user'
            self.logger(request_user, "System-Path: {} already exists.".format(system_evidence_path))
                        ^
./dfirtrack_main/models.py:1247:25: F821 undefined name 'request_user'
            self.logger(request_user, "System-Path: {} created.".format(system_evidence_path))
                        ^
2     F821 undefined name 'request_user'
2
```
The [`System.create_evidence_directory()` method](https://github.com/dfirtrack/dfirtrack/blob/master/dfirtrack_main/models.py#L1236-L1248) needs a `request_user` method parameter like the other 70 uses of that variable name in this file.

The method is not called. https://github.com/dfirtrack/dfirtrack/search?q=create_evidence_directory

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.