### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/ansible/roles/dfirtrack/templates/local_settings.py.j2
+++ b/ansible/roles/dfirtrack/templates/local_settings.py.j2
@@ -1,7 +1,7 @@
 """
 Django settings for DFIRTrack project provided with Ansible.
 
-These settings extend the defaul dfirtrack.settings.
+These settings extend the default dfirtrack.settings.
 """
 
 ALLOWED_HOSTS = ['{{ fqdn }}','localhost']

--- a/dfirtrack/settings.py
+++ b/dfirtrack/settings.py
@@ -185,7 +185,7 @@ MARTOR_ENABLE_LABEL = True
 """
 import local settings from local_settings
 use settings from this file in case of missing local settings
-try statements are splitted to avoid conflicts in case of missing values
+try statements are split to avoid conflicts in case of missing values
 """
 
 # ALLOWED_HOSTS

--- a/dfirtrack/test_settings.py
+++ b/dfirtrack/test_settings.py
@@ -10,5 +10,5 @@ import sys
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
     logging.disable(logging.CRITICAL)
 
-# enable synchronous exection for django-q, async_task() won't work otherwise
+# enable synchronous execution for django-q, async_task() won't work otherwise
 Q_CLUSTER['sync'] = True

--- a/dfirtrack_artifacts/models.py
+++ b/dfirtrack_artifacts/models.py
@@ -148,7 +148,7 @@ class Artifact(models.Model):
         #    self.artifact_storage_path = destination
         #else:
         #    self.artifact_storage_path = artifact_evidence_path
-        ##TODO: check if this works or if wee need
+        ##TODO: check if this works or if we need
         ## super().save(*args,**kwargs)
 
         """ set artifact time according to config """

--- a/dfirtrack_config/forms.py
+++ b/dfirtrack_config/forms.py
@@ -202,7 +202,7 @@ class MainConfigForm(forms.ModelForm):
         artifactstatus_requested = self.cleaned_data['artifactstatus_requested']
         artifactstatus_acquisition = self.cleaned_data['artifactstatus_acquisition']
 
-        # get artifactstatus that have been choosen for both time settings
+        # get artifactstatus that have been chosen for both time settings
         artifactstatus_shared = artifactstatus_requested.intersection(artifactstatus_acquisition)
 
         # check if there are any artifactstatus in this queryset
@@ -216,7 +216,7 @@ class MainConfigForm(forms.ModelForm):
         casestatus_start = self.cleaned_data['casestatus_start']
         casestatus_end = self.cleaned_data['casestatus_end']
 
-        # get casestatus that have been choosen for both time settings
+        # get casestatus that have been chosen for both time settings
         casestatus_shared = casestatus_start.intersection(casestatus_end)
 
         # check if there are any casestatus in this queryset
@@ -1140,7 +1140,7 @@ class SystemImporterFileCsvConfigForm(forms.ModelForm):
     modelformset_factory for WorkflowDefaultArtifactnameFormSet
     to add multiple WorkflowDefaultArtifactname at once
 
-    to add more than one extra WorkflowDefaultArtifactname, refere to template javascript
+    to add more than one extra WorkflowDefaultArtifactname, refer to template javascript
 '''
 
 WorkflowDefaultArtifactAttributesFormSet = forms.modelformset_factory(

--- a/dfirtrack_config/views/status.py
+++ b/dfirtrack_config/views/status.py
@@ -22,7 +22,7 @@ def get_status_objects(context):
 
     # get config model
     main_config_model = MainConfigModel.objects.get(main_config_name = 'MainConfig')
-    # get number of entrys to show
+    # get number of entries to show
     statushistory_entry_numbers = main_config_model .statushistory_entry_numbers
 
     # get last statushistory objects for dropdown menu according to config

--- a/dfirtrack_main/creator/system_creator.py
+++ b/dfirtrack_main/creator/system_creator.py
@@ -61,7 +61,7 @@ def system_creator_async(request_post, request_user):
     # call logger
     debug_logger(str(request_user), ' SYSTEM_CREATOR_START')
 
-    # exctract lines from systemlist (list results from request object via large text area)
+    # extract lines from systemlist (list results from request object via large text area)
     lines = request_post.get('systemlist').splitlines()
 
     #  count lines (needed for messages)
@@ -92,7 +92,7 @@ def system_creator_async(request_post, request_user):
     # iterate over lines
     for line in lines:
 
-        # skip emtpy lines
+        # skip empty lines
         if line == '':
             # autoincrement counter
             lines_faulty_counter += 1

--- a/dfirtrack_main/creator/task_creator.py
+++ b/dfirtrack_main/creator/task_creator.py
@@ -97,7 +97,7 @@ def task_creator_async(request_post, request_user):
 
                 """ object creation """
 
-                # dont't save form yet
+                # don't save form yet
                 task = form.save(commit=False)
 
                 # set taskname and system

--- a/dfirtrack_main/exporter/markdown/checks.py
+++ b/dfirtrack_main/exporter/markdown/checks.py
@@ -30,10 +30,10 @@ def check_content_file_system(request=None):
     if not model.markdown_path:
         # if function was called from 'system'
         if request:
-            messages.error(request, 'Markdown path contains an emtpy string. Check config!')
+            messages.error(request, 'Markdown path contains an empty string. Check config!')
         # if function was called from 'system_cron'
         else:
-            error_message_cron('Markdown path contains an emtpy string. Check config!')
+            error_message_cron('Markdown path contains an empty string. Check config!')
         # call logger
         error_logger(logger_username, ' MARKDOWN_EXPORTER_MARKDOWN_PATH_EMPTY_STRING')
         # set stop condition

--- a/dfirtrack_main/exporter/markdown/clean_directory.py
+++ b/dfirtrack_main/exporter/markdown/clean_directory.py
@@ -12,7 +12,7 @@ def clean_directory(username):
 
     # clean or create markdown directory
     if os.path.exists(model.markdown_path + "/docs/systems/"):
-        # remove markdown directory (recursivly)
+        # remove markdown directory (recursively)
         shutil.rmtree(model.markdown_path + "/docs/systems/")
         # recreate markdown directory
         os.mkdir(model.markdown_path + "/docs/systems/")

--- a/dfirtrack_main/exporter/markdown/domainsorted.py
+++ b/dfirtrack_main/exporter/markdown/domainsorted.py
@@ -13,7 +13,7 @@ import yaml
 
 
 def write_report_domainsorted(system, username):
-    """ function that prepares return values and pathes """
+    """ function that prepares return values and paths """
 
     """
     the return values (prefix 'r') are used for the `mkdocs.yml` file
@@ -102,7 +102,7 @@ def domainsorted(request=None):
     # call logger
     debug_logger(username, " SYSTEM_EXPORTER_MARKDOWN_DOMAINSORTED_START")
 
-    # show immediate message for user (but only if no errors have occured before)
+    # show immediate message for user (but only if no errors have occurred before)
     if request:
         start_message(request, 'domain')
 

--- a/dfirtrack_main/exporter/markdown/systemsorted.py
+++ b/dfirtrack_main/exporter/markdown/systemsorted.py
@@ -10,7 +10,7 @@ import yaml
 
 
 def write_report_systemsorted(system, username):
-    """ function that prepares return values and pathes """
+    """ function that prepares return values and paths """
 
     """
     the return values (prefix 'r') are used for the `mkdocs.yml` file
@@ -86,7 +86,7 @@ def systemsorted(request=None):
     # call logger
     debug_logger(username, " SYSTEM_EXPORTER_MARKDOWN_SYSTEMSORTED_START")
 
-    # show immediate message for user (but only if no errors have occured before)
+    # show immediate message for user (but only if no errors have occurred before)
     if request:
         start_message(request, 'system')
 

--- a/dfirtrack_main/exporter/markdown/write_report.py
+++ b/dfirtrack_main/exporter/markdown/write_report.py
@@ -186,10 +186,10 @@ def write_entries_to_table(django_report, system):
     """ write all entries to table """
 
     # TODO: change behavior, currently check for entry attributes is necessary because of 'null=True'
-    entrys = system.entry_set.all().order_by('entry_date', 'entry_utc')
-    if entrys.exists():
+    entries = system.entry_set.all().order_by('entry_date', 'entry_utc')
+    if entries.exists():
         # iterate over entries
-        for entry in entrys:
+        for entry in entries:
             # print entries line by line
             if entry.entry_date:
                 django_report.write("| " + entry.entry_date + " ")

--- a/dfirtrack_main/exporter/spreadsheet/checks.py
+++ b/dfirtrack_main/exporter/spreadsheet/checks.py
@@ -23,7 +23,7 @@ def check_content_file_system(main_config_model, module_text, request=None):
     if not os.path.isdir(main_config_model.cron_export_path):
         # if function was called from 'artifact_create_cron' / 'system_create_cron'
         if request:
-            # call messsage
+            # call message
             messages.error(request, 'Export path does not exist. Check config or file system!')
         # if function was called from 'artifact_cron' / 'system_cron'
         else:
@@ -38,7 +38,7 @@ def check_content_file_system(main_config_model, module_text, request=None):
         if not os.access(main_config_model.cron_export_path, os.R_OK):
             # if function was called from 'artifact_create_cron' / 'system_create_cron'
             if request:
-                # call messsage
+                # call message
                 messages.error(request, 'No write permission for export path. Check config or file system!')
             # if function was called from 'artifact_cron' / 'system_cron'
             else:

--- a/dfirtrack_main/importer/file/csv_checks.py
+++ b/dfirtrack_main/importer/file/csv_checks.py
@@ -57,7 +57,7 @@ def check_content_file_system(model, request=None):
     if not os.path.isdir(model.csv_import_path):
         # if function was called from 'system_instant'
         if request:
-            # call messsage
+            # call message
             messages.error(request, 'CSV import path does not exist. Check config or file system!')
         # if function was called from 'system_cron'
         else:
@@ -72,7 +72,7 @@ def check_content_file_system(model, request=None):
         if not os.access(model.csv_import_path, os.R_OK):
             # if function was called from 'system_instant'
             if request:
-                # call messsage
+                # call message
                 messages.error(request, 'No read permission for CSV import path. Check config or file system!')
             # if function was called from 'system_cron'
             else:
@@ -87,7 +87,7 @@ def check_content_file_system(model, request=None):
             if not os.path.isfile(csv_import_file):
                 # if function was called from 'system_instant'
                 if request:
-                    # call messsage
+                    # call message
                     messages.error(request, 'CSV import file does not exist. Check config or provide file!')
                 # if function was called from 'system_cron'
                 else:
@@ -102,7 +102,7 @@ def check_content_file_system(model, request=None):
                 if not os.access(csv_import_file, os.R_OK):
                     # if function was called from 'system_instant'
                     if request:
-                        # call messsage
+                        # call message
                         messages.error(request, 'No read permission for CSV import file. Check config or file system!')
                     # if function was called from 'system_cron'
                     else:
@@ -117,7 +117,7 @@ def check_content_file_system(model, request=None):
                     if os.path.getsize(csv_import_file) == 0:
                         # if function was called from 'system_instant'
                         if request:
-                            # call messsage
+                            # call message
                             messages.error(request, 'CSV import file is empty. Check config or file system!')
                         # if function was called from 'system_cron'
                         else:

--- a/dfirtrack_main/modificator/system_modificator.py
+++ b/dfirtrack_main/modificator/system_modificator.py
@@ -77,7 +77,7 @@ def system_modificator_async(request_post, request_user):
     # call logger
     debug_logger(str(request_user), ' SYSTEM_MODIFICATOR_START')
 
-    # exctract lines from systemlist (list results either from request object via multiline selector or via large text area)
+    # extract lines from systemlist (list results either from request object via multiline selector or via large text area)
     lines = request_post.getlist('systemlist')
     system_char_field_used = False
     # if large text area was used, the list contains only one entry with (one or more) line breaks
@@ -115,7 +115,7 @@ def system_modificator_async(request_post, request_user):
     # iterate over lines
     for line in lines:
 
-        # skip emtpy lines
+        # skip empty lines
         if line == '':
             # autoincrement counter
             lines_faulty_counter += 1

--- a/dfirtrack_main/templates/dfirtrack_main/company/company_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/company/company_list.html
@@ -46,7 +46,7 @@
         Division
     </div>
 
-    <!-- syste headline -->
+    <!-- system headline -->
     <div class="col-1">
         Systems
     </div>

--- a/dfirtrack_main/templates/dfirtrack_main/task/task_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/task/task_detail.html
@@ -222,7 +222,7 @@
         <div class="col-3">
         </div>
 
-        <!-- grab / free user assignement button -->
+        <!-- grab / free user assignment button -->
         <div class="col-3">
 
             <!-- grab button -->
@@ -240,7 +240,7 @@
                 </a>
             {% endif %}
 
-        <!-- grab / free user assignement button -->
+        <!-- grab / free user assignment button -->
         </div>
 
     <!-- button row -->

--- a/dfirtrack_main/templates/dfirtrack_main/widgets/tag_widget.html
+++ b/dfirtrack_main/templates/dfirtrack_main/widgets/tag_widget.html
@@ -9,7 +9,7 @@
 <div id="hidden_tags" style="display:none;"> 
     {% for group_name, group_choices, group_index in widget.optgroups %}
         {% for option in group_choices %}   
-            <!-- tag input options.attr.items set django input attributes for exmaple checked items -->
+            <!-- tag input options.attr.items set django input attributes for example checked items -->
             <input 
                 type="{{ option.type }}" name="{{ widget.name }}" value="{{ option.value }}"
                 {% for name, value in option.attrs.items %}

--- a/dfirtrack_main/tests/documentation/test_documentation_view.py
+++ b/dfirtrack_main/tests/documentation/test_documentation_view.py
@@ -17,7 +17,7 @@ class DocumentationViewTestCase(TestCase):
         # create user
         test_user = User.objects.create_user(username='testuser_documentation', password='dRekxM3R5frr')
 
-        #creat objects
+        #create objects
         Case.objects.create(
             case_name='case_1',
             case_is_incident=True,

--- a/dfirtrack_main/tests/note/test_note_models.py
+++ b/dfirtrack_main/tests/note/test_note_models.py
@@ -17,7 +17,7 @@ class NoteModelTestCase(TestCase):
         # create object
         notestatus_1 = Notestatus.objects.create(notestatus_name='notestatus_1')
 
-        #creat objects
+        #create objects
         Case.objects.create(
             case_name='case_1',
             case_is_incident=True,

--- a/dfirtrack_main/tests/system/test_system_exporter_markdown_views.py
+++ b/dfirtrack_main/tests/system/test_system_exporter_markdown_views.py
@@ -206,7 +206,7 @@ class SystemExporterMarkdownViewTestCase(TestCase):
 
         # remove existing and re-create empty markdown directory
         if os.path.exists(markdown_path_filesystem):
-            # remove existing markdown directory (recursivly)
+            # remove existing markdown directory (recursively)
             shutil.rmtree(markdown_path_filesystem)
             # re-create empty markdown directory
             os.makedirs(markdown_path_filesystem)
@@ -265,7 +265,7 @@ class SystemExporterMarkdownViewTestCase(TestCase):
         messages = list(get_messages(response.wsgi_request))
         # compare
         self.assertRedirects(response, destination, status_code=302, target_status_code=200)
-        self.assertEqual(str(messages[0]), 'Markdown path contains an emtpy string. Check config!')
+        self.assertEqual(str(messages[0]), 'Markdown path contains an empty string. Check config!')
         self.assertEqual(messages[0].level_tag, 'error')
 
     def test_system_exporter_markdown_markdown_path_not_existent(self):
@@ -413,7 +413,7 @@ class SystemExporterMarkdownViewTestCase(TestCase):
         messages = list(get_messages(response.wsgi_request))
         # compare
         self.assertEqual(str(response.context['user']), 'testuser_system_exporter_markdown')
-        self.assertEqual(messages[0].message, '[Scheduled task markdown exporter] Markdown path contains an emtpy string. Check config!')
+        self.assertEqual(messages[0].message, '[Scheduled task markdown exporter] Markdown path contains an empty string. Check config!')
         self.assertEqual(messages[0].level_tag, 'error')
         # switch user context
         self.client.logout()
@@ -424,7 +424,7 @@ class SystemExporterMarkdownViewTestCase(TestCase):
         messages = list(get_messages(response.wsgi_request))
         # compare
         self.assertEqual(str(response.context['user']), 'message_user')
-        self.assertEqual(messages[0].message, '[Scheduled task markdown exporter] Markdown path contains an emtpy string. Check config!')
+        self.assertEqual(messages[0].message, '[Scheduled task markdown exporter] Markdown path contains an empty string. Check config!')
         self.assertEqual(messages[0].level_tag, 'error')
 
     def test_system_exporter_markdown_cron_markdown_path_not_existent(self):
@@ -587,7 +587,7 @@ class SystemExporterMarkdownViewTestCase(TestCase):
         messages = list(get_messages(response.wsgi_request))
         # compare
         self.assertRedirects(response, destination, status_code=302, target_status_code=200)
-        self.assertEqual(str(messages[0]), 'Markdown path contains an emtpy string. Check config!')
+        self.assertEqual(str(messages[0]), 'Markdown path contains an empty string. Check config!')
         self.assertEqual(messages[0].level_tag, 'error')
 
     def test_system_exporter_markdown_create_cron_markdown_path_not_existent(self):

--- a/dfirtrack_main/views/system_views.py
+++ b/dfirtrack_main/views/system_views.py
@@ -174,7 +174,7 @@ class SystemUpdate(LoginRequiredMixin, UpdateView):
             ipstring = ipstring + str(ip.ip_ip)
             # increment counter
             i += 1
-            # add newline but not for last occurence
+            # add newline but not for last occurrence
             if i < iplen:
                 ipstring = ipstring + '\n'
 

--- a/dfirtrack_main/widgets.py
+++ b/dfirtrack_main/widgets.py
@@ -12,7 +12,7 @@ class TagWidget(forms.CheckboxSelectMultiple):
          super(TagWidget, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, choices=(), renderer=None):
-        # get all context infromation parent function
+        # get all context information parent function
         context = self.get_context(name, value, attrs)
         # get all tags, import for tag colors
         context['tags'] = Tag.objects.all()

--- a/docker/shared_files/local_settings.py
+++ b/docker/shared_files/local_settings.py
@@ -1,7 +1,7 @@
 """
 Django settings for DFIRTrack project provided with Ansible.
 
-These settings extend the defaul dfirtrack.settings.
+These settings extend the default dfirtrack.settings.
 """
 
 import os


### PR DESCRIPTION
Fixes #118 

$ [`codespell --skip="*.js,*.map" -w`](https://github.com/codespell-project/codespell)