### PR TITLE
Fixed version fo ansible-lint version 5.4.0 due to ansible 2.9 issues…

### DIFF
--- a/.github/workflows/lint_ansible.yml
+++ b/.github/workflows/lint_ansible.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install ansible ansible-lint
+      - run: pip install ansible ansible-lint==5.4.0
       - run: ansible-lint ansible/


### PR DESCRIPTION
Ansible-Lint was just had an majour release update from version 5.4.0 to version 6, this includes the deprecation of ansible 2.9, so we decided to fix the ansible-lint version in the workflow to version 5.4.0