### PR TITLE
Use variables for dependencies

### DIFF
--- a/dfirtrack_api/templates/dfirtrack_api/swagger-ui.html
+++ b/dfirtrack_api/templates/dfirtrack_api/swagger-ui.html
@@ -2,14 +2,15 @@
 <html>
   <head>
     {% load static %}
+    {% load dfirtrack_main_tags %}
     <title>DFIRTrack API - Documentation</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_api/swagger-ui-4.9.0/swagger-ui.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_api/{% dep_swagger_ui_version %}/swagger-ui.css" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="{% static 'dfirtrack_api/swagger-ui-4.9.0/swagger-ui-bundle.js' %}"></script>
+    <script src="{% get_static_prefix %}dfirtrack_api/{% dep_swagger_ui_version %}/swagger-ui-bundle.js"></script>
     <script>
     const ui = SwaggerUIBundle({
         url: "{% url schema_url %}",

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_all.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_all.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -62,7 +63,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_closed.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_closed.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -62,7 +63,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_detail.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_detail.html
@@ -14,11 +14,12 @@
 
 <!-- static files -->
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
 <!-- javascript for datatables -->
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -621,7 +622,7 @@
 
 <!-- javascript for datatables in maintemplate -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_list.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifact/artifact_list.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -62,7 +63,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifactpriority/artifactpriority_detail.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifactpriority/artifactpriority_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -123,7 +124,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifactstatus/artifactstatus_detail.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifactstatus/artifactstatus_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -119,7 +120,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifacttype/artifacttype_detail.html
+++ b/dfirtrack_artifacts/templates/dfirtrack_artifacts/artifacttype/artifacttype_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -130,7 +131,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_config/templates/dfirtrack_config/assignment/assignment.html
+++ b/dfirtrack_config/templates/dfirtrack_config/assignment/assignment.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -578,7 +579,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-    <script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+    <script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/analysisstatus/analysisstatus_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/analysisstatus/analysisstatus_detail.html
@@ -13,10 +13,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -135,7 +136,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/analystmemo/analystmemo_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/analystmemo/analystmemo_list.html
@@ -11,10 +11,11 @@
 
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -145,7 +146,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/case/case_all.html
+++ b/dfirtrack_main/templates/dfirtrack_main/case/case_all.html
@@ -10,8 +10,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/case/case_closed.html
+++ b/dfirtrack_main/templates/dfirtrack_main/case/case_closed.html
@@ -10,8 +10,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/case/case_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/case/case_detail.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -568,7 +569,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- button row -->

--- a/dfirtrack_main/templates/dfirtrack_main/case/case_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/case/case_list.html
@@ -10,8 +10,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/casepriority/casepriority_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/casepriority/casepriority_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -123,7 +124,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/casestatus/casestatus_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/casestatus/casestatus_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -119,7 +120,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/casetype/casetype_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/casetype/casetype_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -130,7 +131,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/documentation/documentation_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/documentation/documentation_list.html
@@ -10,11 +10,12 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 {% load martortags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- martor -->
 {% include "dfirtrack_main/includes/martor_css.html" %}
@@ -459,7 +460,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- martor -->

--- a/dfirtrack_main/templates/dfirtrack_main/entry/entry_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/entry/entry_list.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -167,7 +168,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/mainloginlogout.html
+++ b/dfirtrack_main/templates/dfirtrack_main/mainloginlogout.html
@@ -12,12 +12,13 @@
 
     <!-- load static files -->
     {% load static %}
+    {% load dfirtrack_main_tags %}
 
     <!-- favicon -->
     <link rel="shortcut icon" href="{% static 'dfirtrack_main/img/favicon.ico' %}"/>
 
     <!-- bootstrap CSS -->
-    <link rel="stylesheet" href="{% static 'dfirtrack_main/bootstrap-5.1.3/css/bootstrap.min.css' %}" type = "text/css"/>
+    <link rel="stylesheet" href="{% get_static_prefix %}dfirtrack_main/{% dep_bootstrap_version %}/css/bootstrap.min.css" type = "text/css"/>
 
     <meta name="viewport" content = "width=device-width, initial-scale=1.0">
 

--- a/dfirtrack_main/templates/dfirtrack_main/mainpopup.html
+++ b/dfirtrack_main/templates/dfirtrack_main/mainpopup.html
@@ -11,9 +11,10 @@
 <meta charset="utf-8" />
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- bootstrap CSS -->
-<link rel="stylesheet" href="{% static 'dfirtrack_main/bootstrap-5.1.3/css/bootstrap.min.css' %}" type = "text/css"/>
+<link rel="stylesheet" href="{% get_static_prefix %}dfirtrack_main/{% dep_bootstrap_version %}/css/bootstrap.min.css" type = "text/css"/>
 
 <meta name="viewport" content = "width=device-width, initial-scale=1.0">
 
@@ -48,8 +49,8 @@
 </div>
 
 <!-- bootstrap relevant javascript -->
-<script src="{% static 'dfirtrack_main/jquery-3.6.0/jquery-3.6.0.min.js' %}"></script>
-<script src="{% static 'dfirtrack_main/bootstrap-5.1.3/js/bootstrap.bundle.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_jquery_version %}/{% dep_jquery_version %}.min.js"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_bootstrap_version %}/js/bootstrap.bundle.min.js"></script>
 
 <!-- HTML body -->
 </body>

--- a/dfirtrack_main/templates/dfirtrack_main/maintemplate.html
+++ b/dfirtrack_main/templates/dfirtrack_main/maintemplate.html
@@ -11,8 +11,9 @@
 <meta charset="utf-8" />
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 <link rel="shortcut icon" href="{% static 'dfirtrack_main/img/favicon.ico' %}"/>
-<link rel="stylesheet" href="{% static 'dfirtrack_main/bootstrap-5.1.3/css/bootstrap.min.css' %}" type = "text/css"/>
+<link rel="stylesheet" href="{% get_static_prefix %}dfirtrack_main/{% dep_bootstrap_version %}/css/bootstrap.min.css" type = "text/css"/>
 
 <meta name="viewport" content = "width=device-width, initial-scale=1.0">
 
@@ -27,13 +28,13 @@
 <link rel="stylesheet" href="{% static 'dfirtrack_main/dfirtrack/dfirtrack.css' %}" type = "text/css"/>
 
 <!-- bootstrap relevant javascript -->
-<script src="{% static 'dfirtrack_main/jquery-3.6.0/jquery-3.6.0.min.js' %}"></script>
-<script src="{% static 'dfirtrack_main/bootstrap-5.1.3/js/bootstrap.bundle.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_jquery_version %}/{% dep_jquery_version %}.min.js"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_bootstrap_version %}/js/bootstrap.bundle.min.js"></script>
 
 <!-- custom javascript -->
 <script src="{% static 'dfirtrack_main/dfirtrack/dfirtrack.js' %}"></script>
 <!-- javascript for copy button -->
-<script src="{% static 'dfirtrack_main/clipboard-2.0.10/clipboard.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_clipboard_version %}/clipboard.min.js"></script>
 
 <!-- HTML head -->
 </head>
@@ -42,9 +43,6 @@
 
 <!-- HTML body -->
 <body class="body bg-dark text-light">
-
-<!-- dfirtrack_main.templatetags.dfirtrack_main_tags  -->
-{% load dfirtrack_main_tags %}
 
 <!-- overall container -->
 <div class="container-fluid" style="min-height:95%; ">

--- a/dfirtrack_main/templates/dfirtrack_main/note/note_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/note/note_list.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -82,7 +83,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/notestatus/notestatus_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/notestatus/notestatus_detail.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -179,7 +180,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/reportitem/reportitem_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/reportitem/reportitem_list.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -55,7 +56,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/system/system_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/system/system_detail.html
@@ -14,13 +14,13 @@
 
 <!-- static files -->
 {% load static %}
+{% load dfirtrack_main_tags %}
 {% load martortags %}
 
-
 <!-- CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
 <!-- javascript for datatables -->
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- martor -->
 {% include "dfirtrack_main/includes/martor_css.html" %}
@@ -1569,7 +1569,7 @@
 
 <!-- javascript for datatables in maintemplate -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- martor -->

--- a/dfirtrack_main/templates/dfirtrack_main/system/system_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/system/system_list.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -255,7 +256,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/systemstatus/systemstatus_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/systemstatus/systemstatus_detail.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -133,7 +134,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/tag/tag_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/tag/tag_detail.html
@@ -10,10 +10,11 @@
 </title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -372,7 +373,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-    <script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+    <script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/tag/tag_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/tag/tag_list.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -90,7 +91,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/task/task_all.html
+++ b/dfirtrack_main/templates/dfirtrack_main/task/task_all.html
@@ -8,10 +8,11 @@
 <title>DFIRTrack - All tasks</title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/task/task_closed.html
+++ b/dfirtrack_main/templates/dfirtrack_main/task/task_closed.html
@@ -8,10 +8,11 @@
 <title>DFIRTrack - Closed tasks</title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/task/task_list.html
+++ b/dfirtrack_main/templates/dfirtrack_main/task/task_list.html
@@ -8,10 +8,11 @@
 <title>DFIRTrack - Tasks</title>
 
 {% load static %}
+{% load dfirtrack_main_tags %}
 
 <!-- javascript and CSS for datatables -->
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -61,7 +62,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/taskname/taskname_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/taskname/taskname_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -106,7 +107,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/taskpriority/taskpriority_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/taskpriority/taskpriority_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -104,7 +105,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templates/dfirtrack_main/taskstatus/taskstatus_detail.html
+++ b/dfirtrack_main/templates/dfirtrack_main/taskstatus/taskstatus_detail.html
@@ -11,8 +11,9 @@
 
 <!-- javascript and CSS for datatables -->
 {% load static %}
-<link rel="stylesheet" type="text/css" href="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.css' %}"/>
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.js' %}"></script>
+{% load dfirtrack_main_tags %}
+<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.css"/>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.js"></script>
 
 <!-- HTML head in maintemplate -->
 {% endblock %}
@@ -104,7 +105,7 @@
 
 <!-- javascript for datatables -->
 {% block datatables %}
-<script src="{% static 'dfirtrack_main/datatables-1.11.5/datatables.min.js' %}"></script>
+<script src="{% get_static_prefix %}dfirtrack_main/{% dep_datatables_version %}/datatables.min.js"></script>
 {% endblock %}
 
 <!-- HTML body in maintemplate -->

--- a/dfirtrack_main/templatetags/dfirtrack_main_tags.py
+++ b/dfirtrack_main/templatetags/dfirtrack_main_tags.py
@@ -7,3 +7,23 @@ register = template.Library()
 def dfirtrack_version():
     versionnumber = 'v2.4.6'
     return versionnumber
+
+@register.simple_tag
+def dep_bootstrap_version():
+    return 'bootstrap-5.1.3'
+
+@register.simple_tag
+def dep_clipboard_version():
+    return 'clipboard-2.0.10'
+
+@register.simple_tag
+def dep_datatables_version():
+    return 'datatables-1.11.5'
+
+@register.simple_tag
+def dep_jquery_version():
+    return 'jquery-3.6.0'
+
+@register.simple_tag
+def dep_swagger_ui_version():
+    return 'swagger-ui-4.9.0'

--- a/dfirtrack_main/templatetags/dfirtrack_main_tags.py
+++ b/dfirtrack_main/templatetags/dfirtrack_main_tags.py
@@ -8,21 +8,26 @@ def dfirtrack_version():
     versionnumber = 'v2.4.6'
     return versionnumber
 
+
 @register.simple_tag
 def dep_bootstrap_version():
     return 'bootstrap-5.1.3'
+
 
 @register.simple_tag
 def dep_clipboard_version():
     return 'clipboard-2.0.10'
 
+
 @register.simple_tag
 def dep_datatables_version():
     return 'datatables-1.11.5'
 
+
 @register.simple_tag
 def dep_jquery_version():
     return 'jquery-3.6.0'
+
 
 @register.simple_tag
 def dep_swagger_ui_version():


### PR DESCRIPTION
Version numbers for dependencies are now defined in `/dfirtrack_main/templatetags/dfirtrack_main_tags.py`. With future dependency updates, only the version number in this file has to be updated. And of course the files for the dependency itself.