### PR TITLE
Optimize Docker workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,38 +10,36 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Obtain latest git 
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git
-      - uses: actions/checkout@v2
-      - name: Set version tag
-        id: prepare
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-          # Set version tag
-          echo "::set-output name=VERSION::$VERSION"
+      - uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: 'dfirtrack/dfirtrack'
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: dfirtrack/dfirtrack:${{ steps.prepare.outputs.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: 'linux/amd64,linux/arm64'
-          file: docker/prod/Dockerfile
+          file: 'docker/prod/Dockerfile'


### PR DESCRIPTION
With this pull request, I have updated and optimized the Docker (build) workflow.
The code to identify the version number has been replaced with the [Docker workflow for semantic versioning](https://github.com/docker/metadata-action#semver). For example, the tag 'v1.2.3' will still generate the Docker tag '1.2.3' and additionally '1.2' for the minor version. This behavior can be disabled.
Commits to the branches 'master' and 'develop' will also generate their own Docker tag, because the workflow is executed for these branches.
The _latest_-tag will now point to the newest Git tag and no longer to the last commit to 'master'. This is the default behavior of the workflow. I think that this won't have practical implications for us, because commits to master are usually in combination with a tag.

The created container now also contains some metadata about this repository: a link to the project, the version, the build date and the commit hash. I have kept this default behavior, it might help with debugging at some point.

The code for the actual build of the container has not been changed. We are still building for amd64 and arm64.